### PR TITLE
WIP: "Answered" Flag [Frontend]

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -204,6 +204,10 @@ define('forum/topic/postTools', [
 				if (labelEl.length) {
 					labelEl.text(answered ? 'Mark Unanswered' : 'Mark Answered');
 				}
+
+				// UI update will happen from the socket event handler for this topic;
+				// no immediate DOM insertion here to avoid duplicate insertions.
+
 				hooks.fire('action:post.answered.toggled', { pid: pid, answered: answered });
 			});
 		});

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -184,6 +184,30 @@ define('forum/topic/postTools', [
 			});
 		});
 
+		// Mark/unmark answered
+		postContainer.on('click', '[component="post/mark-answered"]', function (e) {
+			e.preventDefault();
+			const btn = $(this);
+			const pid = getData(btn, 'data-pid');
+			if (!pid) {
+				return;
+			}
+			btn.attr('disabled', 'disabled');
+			socket.emit('posts.toggleAnswered', { pid: pid }, function (err, data) {
+				btn.removeAttr('disabled');
+				if (err) {
+					return alerts.error(err);
+				}
+				const answered = data && data.answered;
+				btn.attr('data-answered', answered ? '1' : '0');
+				const labelEl = btn.find('.mark-answered-label');
+				if (labelEl.length) {
+					labelEl.text(answered ? 'Mark Unanswered' : 'Mark Answered');
+				}
+				hooks.fire('action:post.answered.toggled', { pid: pid, answered: answered });
+			});
+		});
+
 		postContainer.on('click', '[component="post/edit"]', function () {
 			const btn = $(this);
 

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -200,7 +200,8 @@ module.exports = function (Topics) {
 		const pidToPrivs = _.zipObject(parentPids, postPrivileges);
 
 		parentPids = parentPids.filter(p => pidToPrivs[p]['topics:read']);
-		const parentPosts = await posts.getPostsFields(parentPids, ['uid', 'pid', 'timestamp', 'content', 'sourceContent', 'deleted']);
+		// Include 'answered' so parent previews will render the ANSWERED badge
+		const parentPosts = await posts.getPostsFields(parentPids, ['uid', 'pid', 'timestamp', 'content', 'sourceContent', 'deleted', 'answered']);
 		const parentUids = _.uniq(parentPosts.map(postObj => postObj && postObj.uid));
 		const userData = await user.getUsersFields(parentUids, ['username', 'userslug', 'picture']);
 
@@ -219,6 +220,14 @@ module.exports = function (Topics) {
 			}
 			parentPost = await posts.parsePost(parentPost);
 		}));
+
+		// Debug: log how many parent posts include answered
+		try {
+			const parentsWithAnswered = parentPosts.filter(p => p && p.hasOwnProperty('answered')).length;
+			console.log('[Topics.addParentPosts] parentPids=%d fetched=%d withAnswered=%d', parentPids.length, parentPosts.length, parentsWithAnswered);
+		} catch (e) {
+			// ignore
+		}
 
 		const parents = {};
 		parentPosts.forEach((post, i) => {

--- a/src/views/partials/topic/post-menu-list.tpl
+++ b/src/views/partials/topic/post-menu-list.tpl
@@ -140,6 +140,12 @@
 	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/flagUser" role="menuitem" href="#"><i class="fa fa-fw text-secondary fa-flag"></i> [[topic:flag-user]]</a>
 </li>
 {{{ end }}}
+<li>
+	<a class="dropdown-item rounded-1 d-flex align-items-center gap-2" component="post/mark-answered" role="menuitem" href="#" data-answered="{{{ if posts.answered }}}1{{{ else }}}0{{{ end }}}">
+		<span class="menu-icon"><i class="fa fa-fw text-secondary fa-check"></i></span>
+		<span class="mark-answered-label">{{{ if posts.answered }}}Mark Unanswered{{{ else }}}Mark Answered{{{ end }}}</span>
+	</a>
+</li>
 {{{ end }}}
 
 {{{ if posts.display_moderator_tools }}}

--- a/src/views/partials/topic/post-parent.tpl
+++ b/src/views/partials/topic/post-parent.tpl
@@ -6,6 +6,11 @@
 		</div>
 
 		<a href="{config.relative_path}/post/{encodeURIComponent(./parent.pid)}" class="text-muted timeago text-nowrap hidden" title="{./parent.timestampISO}"></a>
-	</div>
+
+		{{{ if ./parent.answered }}}
+		<span class="ms-2 text-success fw-bold post-answered-badge">ANSWERED</span>
+		{{{ end }}}
+
+		</div>
 	<div component="post/parent/content" class="text-muted line-clamp-1 text-break w-100">{./parent.content}</div>
 </div>

--- a/src/views/partials/topic/post-preview.tpl
+++ b/src/views/partials/topic/post-preview.tpl
@@ -7,6 +7,9 @@
             </div>
             <div>
                 <a href="{config.relative_path}/post/{post.pid}" class="timeago text-xs text-secondary lh-1" style="vertical-align: middle;" title="{post.timestampISO}"></a>
+                {{{ if post.answered }}}
+                <span class="ms-2 text-success fw-bold post-answered-badge">ANSWERED</span>
+                {{{ end }}
             </div>
         </div>
         <div class="content ghost-scrollbar" style="max-height: 300px; overflow-y:auto;">{post.content}</div>

--- a/src/views/partials/topic/post-preview.tpl
+++ b/src/views/partials/topic/post-preview.tpl
@@ -9,7 +9,7 @@
                 <a href="{config.relative_path}/post/{post.pid}" class="timeago text-xs text-secondary lh-1" style="vertical-align: middle;" title="{post.timestampISO}"></a>
                 {{{ if post.answered }}}
                 <span class="ms-2 text-success fw-bold post-answered-badge">ANSWERED</span>
-                {{{ end }}
+                {{{ end }}}
             </div>
         </div>
         <div class="content ghost-scrollbar" style="max-height: 300px; overflow-y:auto;">{post.content}</div>

--- a/tools/smoke-toggle.js
+++ b/tools/smoke-toggle.js
@@ -1,0 +1,22 @@
+const io = require('socket.io-client');
+
+const url = process.env.NODEBB_URL || 'http://localhost:4567';
+const socket = io(url, { transports: ['websocket'], reconnection: false });
+
+socket.on('connect', () => {
+  console.log('connected', socket.id);
+  socket.emit('posts.toggleAnswered', { pid: 1 }, (err, data) => {
+    console.log('callback err=', err, 'data=', data);
+    socket.disconnect();
+    process.exit(0);
+  });
+});
+
+socket.on('connect_error', (err) => {
+  console.error('connect_error', err.message || err);
+  process.exit(1);
+});
+
+socket.on('event:post_answered', (d) => {
+  console.log('received event:post_answered', d);
+});

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -1,7 +1,7 @@
 <ul component="category" class="topics-list list-unstyled" itemscope itemtype="http://www.schema.org/ItemList" data-nextstart="{nextStart}" data-set="{set}">
 
 	{{{ each topics }}}
-	<li component="category/topic" class="category-item hover-parent border-bottom py-3 py-lg-4 d-flex flex-column flex-lg-row align-items-start {function.generateTopicClass}" <!-- IMPORT partials/data/category.tpl -->>
+	<li component="category/topic" class="category-item hover-parent border-bottom py-3 py-lg-4 d-flex flex-column flex-lg-row align-items-start {function.generateTopicClass}" {{{ if ./teaser.pid }}}data-teaser-pid="{./teaser.pid}"{{{ end }}} <!-- IMPORT partials/data/category.tpl -->>
 		<link itemprop="url" content="{config.relative_path}/topic/{./slug}" />
 		<meta itemprop="name" content="{function.stripTags, ./title}" />
 		<meta itemprop="itemListOrder" content="descending" />
@@ -69,7 +69,7 @@
 						<a href="{config.relative_path}/topic/{./slug}{{{ if (./teaser.timestampISO && !config.theme.mobileTopicTeasers) }}}/{./teaser.index}{{{ end }}}" class="border badge bg-transparent text-muted fw-normal timeago" title="{{{ if (./teaser.timestampISO && !config.theme.mobileTopicTeasers) }}}{./teaser.timestampISO}{{{ else }}}{./timestampISO}{{{ end }}}"></a>
 					</div>
 
-					<a href="{config.relative_path}/topic/{./slug}" class="d-none d-lg-block badge bg-transparent text-muted fw-normal timeago" title="{./timestampISO}"></a>
+						<a href="{config.relative_path}/topic/{./slug}" class="d-none d-lg-block badge bg-transparent text-muted fw-normal timeago" title="{./timestampISO}"></a>
 				</span>
 				{{{ if showSelect }}}
 				<div class="checkbox position-absolute top-0 end-0 m-0 d-flex d-lg-none" style="max-width:max-content">
@@ -116,6 +116,9 @@
 					<div class="ps-2">
 						<a href="{{{ if ./teaser.user.userslug }}}{config.relative_path}/user/{./teaser.user.userslug}{{{ else }}}#{{{ end }}}" class="text-decoration-none avatar-tooltip" title="{./teaser.user.displayname}">{buildAvatar(./teaser.user, "18px", true)}</a>
 						<a class="permalink text-muted timeago text-xs" href="{config.relative_path}/topic/{./slug}/{./teaser.index}" title="{./teaser.timestampISO}" aria-label="[[global:lastpost]]"></a>
+						{{{ if ./teaser.answered }}}
+						<span class="ms-2 text-success fw-bold post-answered-badge">ANSWERED</span>
+						{{{ end }}}
 					</div>
 					<div class="post-content text-xs ps-2 line-clamp-sm-2 lh-sm text-break position-relative flex-fill">
 						<a class="stretched-link" tabindex="-1" href="{config.relative_path}/topic/{./slug}/{./teaser.index}" aria-label="[[global:lastpost]]"></a>


### PR DESCRIPTION
Issue addressed more components than expected. Size of the Issue was changed from M to XL

**Progress Made:**

- On the posts page, the dropdown tools has an added button that switches between "Mark Answered" and "Mark Unanswered", setting the field _answered_ accordingly.
<img width="312" height="422" alt="image" src="https://github.com/user-attachments/assets/30ebf845-809a-461c-9f3e-0d57b21d7515" />

- On the same posts page, when marked answered, the "ANSWERED" flag appears next to time stamp
<img width="977" height="101" alt="image" src="https://github.com/user-attachments/assets/60551f6f-27d8-49eb-bd34-c7b1ffbe9fd5" />

- On the categories page (Eg - General DIscussions), the "ANSWERED" flag also appears
<img width="1965" height="145" alt="Screenshot 2025-09-26 193353" src="https://github.com/user-attachments/assets/2d2383fa-c936-4c31-8d5a-9aa454e6cdc6" />

**Bugs to be FIxed**

- "Mark Answered" privileges should only be granted to admins (ie TAs and Professors)
- On the Categories Page, Flag should appear after the Title not the timestamp
- When clicking out of the Post page and clicking in again, ANSWERED flag seems to disappear

**To be Done**
- Added Testing